### PR TITLE
Fixing Zaphod Bongo Cat for LVGL 8.3 and Zephyr 3.5.0, and to work as a module.

### DIFF
--- a/boards/shields/zaphod_lite/Kconfig
+++ b/boards/shields/zaphod_lite/Kconfig
@@ -20,5 +20,4 @@ config ZAPHOD_BONGO_CAT_SLOW_LIMIT
 
 endif # ZAPHOD_BONGO_CAT
 
-
-endif
+endif # ZMK_DISPLAY

--- a/boards/shields/zaphod_lite/Kconfig
+++ b/boards/shields/zaphod_lite/Kconfig
@@ -5,8 +5,8 @@ if ZMK_DISPLAY
 menuconfig ZAPHOD_BONGO_CAT
     bool "Show WPM bongo cat"
     select ZMK_WPM
-    select LVGL_USE_IMG
-    select LVGL_USE_ANIMATION
+    select LV_USE_IMG
+    select LV_USE_ANIMATION
 
 if ZAPHOD_BONGO_CAT
 

--- a/boards/shields/zaphod_lite/Kconfig.defconfig
+++ b/boards/shields/zaphod_lite/Kconfig.defconfig
@@ -12,6 +12,7 @@ config SPI
 config ZMK_DISPLAY
 	select LV_USE_CONT
 	select LV_FONT_MONTSERRAT_26
+        select LV_USE_IMG
 
 if ZMK_DISPLAY
 

--- a/boards/shields/zaphod_lite/Kconfig.defconfig
+++ b/boards/shields/zaphod_lite/Kconfig.defconfig
@@ -12,7 +12,6 @@ config SPI
 config ZMK_DISPLAY
 	select LV_USE_CONT
 	select LV_FONT_MONTSERRAT_26
-        select LV_USE_IMG
 
 if ZMK_DISPLAY
 

--- a/boards/shields/zaphod_lite/Kconfig.shield
+++ b/boards/shields/zaphod_lite/Kconfig.shield
@@ -3,3 +3,25 @@
 
 config SHIELD_ZAPHOD_LITE
    def_bool $(shields_list_contains,zaphod_lite)
+
+if ZMK_DISPLAY
+
+menuconfig ZAPHOD_BONGO_CAT
+    bool "Show WPM bongo cat"
+    select ZMK_WPM
+    select LVGL_USE_IMG
+    select LVGL_USE_ANIMATION
+
+if ZAPHOD_BONGO_CAT
+
+config ZAPHOD_BONGO_CAT_IDLE_LIMIT
+    int "Upper limit for WPM for showing idle animation"
+    default 30
+
+config ZAPHOD_BONGO_CAT_SLOW_LIMIT
+    int "Upper limit for WPM for showing slow typing image"
+    default 60
+
+endif # ZAPHOD_BONGO_CAT
+
+endif # ZMK_DISPLAY

--- a/boards/shields/zaphod_lite/Kconfig.shield
+++ b/boards/shields/zaphod_lite/Kconfig.shield
@@ -3,25 +3,3 @@
 
 config SHIELD_ZAPHOD_LITE
    def_bool $(shields_list_contains,zaphod_lite)
-
-if ZMK_DISPLAY
-
-menuconfig ZAPHOD_BONGO_CAT
-    bool "Show WPM bongo cat"
-    select ZMK_WPM
-    select LVGL_USE_IMG
-    select LVGL_USE_ANIMATION
-
-if ZAPHOD_BONGO_CAT
-
-config ZAPHOD_BONGO_CAT_IDLE_LIMIT
-    int "Upper limit for WPM for showing idle animation"
-    default 30
-
-config ZAPHOD_BONGO_CAT_SLOW_LIMIT
-    int "Upper limit for WPM for showing slow typing image"
-    default 60
-
-endif # ZAPHOD_BONGO_CAT
-
-endif # ZMK_DISPLAY

--- a/boards/shields/zaphod_lite/Kconfig.shield
+++ b/boards/shields/zaphod_lite/Kconfig.shield
@@ -4,3 +4,24 @@
 config SHIELD_ZAPHOD_LITE
    def_bool $(shields_list_contains,zaphod_lite)
 
+if ZMK_DISPLAY
+
+menuconfig ZAPHOD_BONGO_CAT
+    bool "Show WPM bongo cat"
+    select ZMK_WPM
+    select LVGL_USE_IMG
+    select LVGL_USE_ANIMATION
+
+if ZAPHOD_BONGO_CAT
+
+config ZAPHOD_BONGO_CAT_IDLE_LIMIT
+    int "Upper limit for WPM for showing idle animation"
+    default 30
+
+config ZAPHOD_BONGO_CAT_SLOW_LIMIT
+    int "Upper limit for WPM for showing slow typing image"
+    default 60
+
+endif # ZAPHOD_BONGO_CAT
+
+endif # ZMK_DISPLAY

--- a/boards/shields/zaphod_lite/Kconfig.shield
+++ b/boards/shields/zaphod_lite/Kconfig.shield
@@ -9,8 +9,8 @@ if ZMK_DISPLAY
 menuconfig ZAPHOD_BONGO_CAT
     bool "Show WPM bongo cat"
     select ZMK_WPM
-    select LVGL_USE_IMG
-    select LVGL_USE_ANIMATION
+    select LV_USE_IMG
+    select LV_USE_ANIMATION
 
 if ZAPHOD_BONGO_CAT
 

--- a/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
+++ b/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
@@ -97,6 +97,8 @@ void state_widget_wpm(struct zaphod_bongo_cat_widget *widget, int wpm) {
 int zaphod_bongo_cat_widget_init(struct zaphod_bongo_cat_widget *widget, lv_obj_t *parent) {
     widget->obj = lv_img_create(parent);
 
+    lv_obj_set_width(widget->obj, LV_SIZE_CONTENT);
+    lv_obj_set_height(widget->obj, LV_SIZE_CONTENT);
     state_widget_wpm(widget, 0);
 
     sys_slist_append(&widgets, &widget->node);

--- a/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
+++ b/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
@@ -48,7 +48,7 @@ const void* fast_images[] = {
 	&fast_img2,
 };
 
-void set_img_src(void *var, lv_anim_value_t val) {
+void set_img_src(void *var, int32_t val) {
     lv_obj_t *img = (lv_obj_t *)var;
     lv_img_set_src(img, images[val]);
 }
@@ -95,10 +95,9 @@ void state_widget_wpm(struct zaphod_bongo_cat_widget *widget, int wpm) {
 }
 
 int zaphod_bongo_cat_widget_init(struct zaphod_bongo_cat_widget *widget, lv_obj_t *parent) {
-    widget->obj = lv_img_create(parent, NULL);
+    widget->obj = lv_img_create(parent);
     
 
-    lv_img_set_auto_size(widget->obj, true);
     state_widget_wpm(widget, 0);
 
     sys_slist_append(&widgets, &widget->node);

--- a/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
+++ b/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
@@ -10,134 +10,113 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
-/* #include "zaphod_bongo_cat_widget.h" */
-
-/* static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets); */
-
-/* enum anim_state { */
-/* 	anim_state_none, */
-/* 	anim_state_idle, */
-/* 	anim_state_slow, */
-/* 	anim_state_fast */
-/* } current_anim_state; */
-
-/* const void* *images; */
-/* uint8_t images_len; */
-
-/* LV_IMG_DECLARE(idle_img1); */
-/* LV_IMG_DECLARE(idle_img2); */
-/* LV_IMG_DECLARE(idle_img3); */
-/* LV_IMG_DECLARE(idle_img4); */
-/* LV_IMG_DECLARE(idle_img5); */
-
-/* LV_IMG_DECLARE(slow_img); */
-
-/* LV_IMG_DECLARE(fast_img1); */
-/* LV_IMG_DECLARE(fast_img2); */
-
-/* const void* idle_images[] = { */
-/* 	&idle_img1, */
-/* 	&idle_img2, */
-/* 	&idle_img3, */
-/* 	&idle_img4, */
-/* 	&idle_img5, */
-/* }; */
-
-/* const void* fast_images[] = { */
-/* 	&fast_img1, */
-/* 	&fast_img2, */
-/* }; */
-
-/* void set_img_src(void *var, lv_anim_value_t val) { */
-/*     lv_obj_t *img = (lv_obj_t *)var; */
-/*     lv_img_set_src(img, images[val]); */
-/* } */
-
-
-/* void state_widget_wpm(struct zaphod_bongo_cat_widget *widget, int wpm) { */
-/*     LOG_DBG("anim state %d", current_anim_state); */
-/*     if (wpm < CONFIG_ZAPHOD_BONGO_CAT_IDLE_LIMIT) { */
-/* 	if (current_anim_state != anim_state_idle) { */
-/* 	    LOG_DBG("Set source to idle images!"); */
-/*             lv_anim_init(&widget->anim); */
-/*             lv_anim_set_var(&widget->anim, widget->obj); */
-/* 	    lv_anim_set_time(&widget->anim, 1000); */
-/* 	    lv_anim_set_values(&widget->anim, 0, 4); */
-/* 	    lv_anim_set_exec_cb(&widget->anim, set_img_src); */
-/* 	    lv_anim_set_repeat_count(&widget->anim, 10); */
-/* 	    lv_anim_set_repeat_delay(&widget->anim, 100); */
-/* 	    images = idle_images; */
-/* 	    current_anim_state = anim_state_idle; */
-/* 	    lv_anim_start(&widget->anim); */
-/* 	} */
-/*     } else if (wpm < CONFIG_ZAPHOD_BONGO_CAT_SLOW_LIMIT) { */
-/* 	if (current_anim_state != anim_state_slow) { */
-/* 	    LOG_DBG("Set source to slow image!"); */
-/* 	    lv_anim_del(widget->obj, set_img_src); */
-/* 	    lv_img_set_src(widget->obj, &slow_img); */
-/* 	    current_anim_state = anim_state_slow; */
-/* 	} */
-/*     } else { */
-/* 	if (current_anim_state != anim_state_fast) { */
-/* 	    LOG_DBG("Set source to fast images!"); */
-/*             lv_anim_init(&widget->anim); */
-/* 	    lv_anim_set_time(&widget->anim, 500); */
-/* 	    lv_anim_set_repeat_delay(&widget->anim, 500); */
-/*             lv_anim_set_var(&widget->anim, widget->obj); */
-/* 	    lv_anim_set_values(&widget->anim, 0, 1); */
-/* 	    lv_anim_set_exec_cb(&widget->anim, set_img_src); */
-/* 	    lv_anim_set_repeat_count(&widget->anim, LV_ANIM_REPEAT_INFINITE); */
-/* 	    images = fast_images; */
-/* 	    current_anim_state = anim_state_fast; */
-/* 	    lv_anim_start(&widget->anim); */
-/* 	} */
-/*     } */
-/* } */
-
-/* int zaphod_bongo_cat_widget_init(struct zaphod_bongo_cat_widget *widget, lv_obj_t *parent) { */
-/*     widget->obj = lv_img_create(parent, NULL); */
-    
-
-/*     lv_img_set_auto_size(widget->obj, true); */
-/*     state_widget_wpm(widget, 0); */
-
-/*     sys_slist_append(&widgets, &widget->node); */
-
-/*     return 0; */
-/* } */
-
-/* lv_obj_t *zaphod_bongo_cat_widget_obj(struct zaphod_bongo_cat_widget  *widget) { */
-/*     return widget->obj; */
-/* } */
-
-/* int wpm_status_listener(const zmk_event_t *eh) { */
-/*     struct zaphod_bongo_cat_widget *widget; */
-/*     struct zmk_wpm_state_changed *ev = as_zmk_wpm_state_changed(eh); */
-/*     LOG_DBG("LISTENER"); */
-/*     SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) { LOG_DBG("Set the WPM %d", ev->state); state_widget_wpm(widget, ev->state); } */
-/*     return ZMK_EV_EVENT_BUBBLE; */
-/* } */
-
-/* ZMK_LISTENER(zaphod_bongo_cat_widget, wpm_status_listener) */
-/* ZMK_SUBSCRIPTION(zaphod_bongo_cat_widget, zmk_wpm_state_changed); */
-
-#include <lvgl.h>
-
 #include "zaphod_bongo_cat_widget.h"
 
 static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
 
+enum anim_state {
+	anim_state_none,
+	anim_state_idle,
+	anim_state_slow,
+	anim_state_fast
+} current_anim_state;
+
+const void* *images;
+uint8_t images_len;
+
+LV_IMG_DECLARE(idle_img1);
+LV_IMG_DECLARE(idle_img2);
+LV_IMG_DECLARE(idle_img3);
+LV_IMG_DECLARE(idle_img4);
+LV_IMG_DECLARE(idle_img5);
+
+LV_IMG_DECLARE(slow_img);
+
+LV_IMG_DECLARE(fast_img1);
+LV_IMG_DECLARE(fast_img2);
+
+const void* idle_images[] = {
+	&idle_img1,
+	&idle_img2,
+	&idle_img3,
+	&idle_img4,
+	&idle_img5,
+};
+
+const void* fast_images[] = {
+	&fast_img1,
+	&fast_img2,
+};
+
+void set_img_src(void *var, lv_anim_value_t val) {
+    lv_obj_t *img = (lv_obj_t *)var;
+    lv_img_set_src(img, images[val]);
+}
+
+
+void state_widget_wpm(struct zaphod_bongo_cat_widget *widget, int wpm) {
+    LOG_DBG("anim state %d", current_anim_state);
+    if (wpm < CONFIG_ZAPHOD_BONGO_CAT_IDLE_LIMIT) {
+	if (current_anim_state != anim_state_idle) {
+	    LOG_DBG("Set source to idle images!");
+            lv_anim_init(&widget->anim);
+            lv_anim_set_var(&widget->anim, widget->obj);
+	    lv_anim_set_time(&widget->anim, 1000);
+	    lv_anim_set_values(&widget->anim, 0, 4);
+	    lv_anim_set_exec_cb(&widget->anim, set_img_src);
+	    lv_anim_set_repeat_count(&widget->anim, 10);
+	    lv_anim_set_repeat_delay(&widget->anim, 100);
+	    images = idle_images;
+	    current_anim_state = anim_state_idle;
+	    lv_anim_start(&widget->anim);
+	}
+    } else if (wpm < CONFIG_ZAPHOD_BONGO_CAT_SLOW_LIMIT) {
+	if (current_anim_state != anim_state_slow) {
+	    LOG_DBG("Set source to slow image!");
+	    lv_anim_del(widget->obj, set_img_src);
+	    lv_img_set_src(widget->obj, &slow_img);
+	    current_anim_state = anim_state_slow;
+	}
+    } else {
+	if (current_anim_state != anim_state_fast) {
+	    LOG_DBG("Set source to fast images!");
+            lv_anim_init(&widget->anim);
+	    lv_anim_set_time(&widget->anim, 500);
+	    lv_anim_set_repeat_delay(&widget->anim, 500);
+            lv_anim_set_var(&widget->anim, widget->obj);
+	    lv_anim_set_values(&widget->anim, 0, 1);
+	    lv_anim_set_exec_cb(&widget->anim, set_img_src);
+	    lv_anim_set_repeat_count(&widget->anim, LV_ANIM_REPEAT_INFINITE);
+	    images = fast_images;
+	    current_anim_state = anim_state_fast;
+	    lv_anim_start(&widget->anim);
+	}
+    }
+}
+
 int zaphod_bongo_cat_widget_init(struct zaphod_bongo_cat_widget *widget, lv_obj_t *parent) {
-  widget->obj = lv_img_create(parent, NULL);
+    widget->obj = lv_img_create(parent, NULL);
+    
 
-  lv_img_set_auto_size(widget->obj, true);
-  // state_widget_wpm(widget, 0);
+    lv_img_set_auto_size(widget->obj, true);
+    state_widget_wpm(widget, 0);
 
-  sys_slist_append(&widgets, &widget->node);
+    sys_slist_append(&widgets, &widget->node);
 
-  return 0;
+    return 0;
 }
 
-lv_obj_t *zaphod_bongo_cat_widget_obj(struct zaphod_bongo_cat_widget *widget) {
-  return widget->obj;
+lv_obj_t *zaphod_bongo_cat_widget_obj(struct zaphod_bongo_cat_widget  *widget) {
+    return widget->obj;
 }
+
+int wpm_status_listener(const zmk_event_t *eh) {
+    struct zaphod_bongo_cat_widget *widget;
+    struct zmk_wpm_state_changed *ev = as_zmk_wpm_state_changed(eh);
+    LOG_DBG("LISTENER");
+    SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) { LOG_DBG("Set the WPM %d", ev->state); state_widget_wpm(widget, ev->state); }
+    return ZMK_EV_EVENT_BUBBLE;
+}
+
+ZMK_LISTENER(zaphod_bongo_cat_widget, wpm_status_listener)
+ZMK_SUBSCRIPTION(zaphod_bongo_cat_widget, zmk_wpm_state_changed);

--- a/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
+++ b/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
@@ -96,7 +96,6 @@ void state_widget_wpm(struct zaphod_bongo_cat_widget *widget, int wpm) {
 
 int zaphod_bongo_cat_widget_init(struct zaphod_bongo_cat_widget *widget, lv_obj_t *parent) {
     widget->obj = lv_img_create(parent);
-    
 
     state_widget_wpm(widget, 0);
 

--- a/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
+++ b/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
@@ -7,7 +7,7 @@
 #include <zmk/event_manager.h>
 #include <zmk/events/wpm_state_changed.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #include "zaphod_bongo_cat_widget.h"

--- a/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
+++ b/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
@@ -10,113 +10,134 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
+/* #include "zaphod_bongo_cat_widget.h" */
+
+/* static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets); */
+
+/* enum anim_state { */
+/* 	anim_state_none, */
+/* 	anim_state_idle, */
+/* 	anim_state_slow, */
+/* 	anim_state_fast */
+/* } current_anim_state; */
+
+/* const void* *images; */
+/* uint8_t images_len; */
+
+/* LV_IMG_DECLARE(idle_img1); */
+/* LV_IMG_DECLARE(idle_img2); */
+/* LV_IMG_DECLARE(idle_img3); */
+/* LV_IMG_DECLARE(idle_img4); */
+/* LV_IMG_DECLARE(idle_img5); */
+
+/* LV_IMG_DECLARE(slow_img); */
+
+/* LV_IMG_DECLARE(fast_img1); */
+/* LV_IMG_DECLARE(fast_img2); */
+
+/* const void* idle_images[] = { */
+/* 	&idle_img1, */
+/* 	&idle_img2, */
+/* 	&idle_img3, */
+/* 	&idle_img4, */
+/* 	&idle_img5, */
+/* }; */
+
+/* const void* fast_images[] = { */
+/* 	&fast_img1, */
+/* 	&fast_img2, */
+/* }; */
+
+/* void set_img_src(void *var, lv_anim_value_t val) { */
+/*     lv_obj_t *img = (lv_obj_t *)var; */
+/*     lv_img_set_src(img, images[val]); */
+/* } */
+
+
+/* void state_widget_wpm(struct zaphod_bongo_cat_widget *widget, int wpm) { */
+/*     LOG_DBG("anim state %d", current_anim_state); */
+/*     if (wpm < CONFIG_ZAPHOD_BONGO_CAT_IDLE_LIMIT) { */
+/* 	if (current_anim_state != anim_state_idle) { */
+/* 	    LOG_DBG("Set source to idle images!"); */
+/*             lv_anim_init(&widget->anim); */
+/*             lv_anim_set_var(&widget->anim, widget->obj); */
+/* 	    lv_anim_set_time(&widget->anim, 1000); */
+/* 	    lv_anim_set_values(&widget->anim, 0, 4); */
+/* 	    lv_anim_set_exec_cb(&widget->anim, set_img_src); */
+/* 	    lv_anim_set_repeat_count(&widget->anim, 10); */
+/* 	    lv_anim_set_repeat_delay(&widget->anim, 100); */
+/* 	    images = idle_images; */
+/* 	    current_anim_state = anim_state_idle; */
+/* 	    lv_anim_start(&widget->anim); */
+/* 	} */
+/*     } else if (wpm < CONFIG_ZAPHOD_BONGO_CAT_SLOW_LIMIT) { */
+/* 	if (current_anim_state != anim_state_slow) { */
+/* 	    LOG_DBG("Set source to slow image!"); */
+/* 	    lv_anim_del(widget->obj, set_img_src); */
+/* 	    lv_img_set_src(widget->obj, &slow_img); */
+/* 	    current_anim_state = anim_state_slow; */
+/* 	} */
+/*     } else { */
+/* 	if (current_anim_state != anim_state_fast) { */
+/* 	    LOG_DBG("Set source to fast images!"); */
+/*             lv_anim_init(&widget->anim); */
+/* 	    lv_anim_set_time(&widget->anim, 500); */
+/* 	    lv_anim_set_repeat_delay(&widget->anim, 500); */
+/*             lv_anim_set_var(&widget->anim, widget->obj); */
+/* 	    lv_anim_set_values(&widget->anim, 0, 1); */
+/* 	    lv_anim_set_exec_cb(&widget->anim, set_img_src); */
+/* 	    lv_anim_set_repeat_count(&widget->anim, LV_ANIM_REPEAT_INFINITE); */
+/* 	    images = fast_images; */
+/* 	    current_anim_state = anim_state_fast; */
+/* 	    lv_anim_start(&widget->anim); */
+/* 	} */
+/*     } */
+/* } */
+
+/* int zaphod_bongo_cat_widget_init(struct zaphod_bongo_cat_widget *widget, lv_obj_t *parent) { */
+/*     widget->obj = lv_img_create(parent, NULL); */
+    
+
+/*     lv_img_set_auto_size(widget->obj, true); */
+/*     state_widget_wpm(widget, 0); */
+
+/*     sys_slist_append(&widgets, &widget->node); */
+
+/*     return 0; */
+/* } */
+
+/* lv_obj_t *zaphod_bongo_cat_widget_obj(struct zaphod_bongo_cat_widget  *widget) { */
+/*     return widget->obj; */
+/* } */
+
+/* int wpm_status_listener(const zmk_event_t *eh) { */
+/*     struct zaphod_bongo_cat_widget *widget; */
+/*     struct zmk_wpm_state_changed *ev = as_zmk_wpm_state_changed(eh); */
+/*     LOG_DBG("LISTENER"); */
+/*     SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) { LOG_DBG("Set the WPM %d", ev->state); state_widget_wpm(widget, ev->state); } */
+/*     return ZMK_EV_EVENT_BUBBLE; */
+/* } */
+
+/* ZMK_LISTENER(zaphod_bongo_cat_widget, wpm_status_listener) */
+/* ZMK_SUBSCRIPTION(zaphod_bongo_cat_widget, zmk_wpm_state_changed); */
+
+#include <lvgl.h>
+
 #include "zaphod_bongo_cat_widget.h"
 
 static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
 
-enum anim_state {
-	anim_state_none,
-	anim_state_idle,
-	anim_state_slow,
-	anim_state_fast
-} current_anim_state;
-
-const void* *images;
-uint8_t images_len;
-
-LV_IMG_DECLARE(idle_img1);
-LV_IMG_DECLARE(idle_img2);
-LV_IMG_DECLARE(idle_img3);
-LV_IMG_DECLARE(idle_img4);
-LV_IMG_DECLARE(idle_img5);
-
-LV_IMG_DECLARE(slow_img);
-
-LV_IMG_DECLARE(fast_img1);
-LV_IMG_DECLARE(fast_img2);
-
-const void* idle_images[] = {
-	&idle_img1,
-	&idle_img2,
-	&idle_img3,
-	&idle_img4,
-	&idle_img5,
-};
-
-const void* fast_images[] = {
-	&fast_img1,
-	&fast_img2,
-};
-
-void set_img_src(void *var, lv_anim_value_t val) {
-    lv_obj_t *img = (lv_obj_t *)var;
-    lv_img_set_src(img, images[val]);
-}
-
-
-void state_widget_wpm(struct zaphod_bongo_cat_widget *widget, int wpm) {
-    LOG_DBG("anim state %d", current_anim_state);
-    if (wpm < CONFIG_ZAPHOD_BONGO_CAT_IDLE_LIMIT) {
-	if (current_anim_state != anim_state_idle) {
-	    LOG_DBG("Set source to idle images!");
-            lv_anim_init(&widget->anim);
-            lv_anim_set_var(&widget->anim, widget->obj);
-	    lv_anim_set_time(&widget->anim, 1000);
-	    lv_anim_set_values(&widget->anim, 0, 4);
-	    lv_anim_set_exec_cb(&widget->anim, set_img_src);
-	    lv_anim_set_repeat_count(&widget->anim, 10);
-	    lv_anim_set_repeat_delay(&widget->anim, 100);
-	    images = idle_images;
-	    current_anim_state = anim_state_idle;
-	    lv_anim_start(&widget->anim);
-	}
-    } else if (wpm < CONFIG_ZAPHOD_BONGO_CAT_SLOW_LIMIT) {
-	if (current_anim_state != anim_state_slow) {
-	    LOG_DBG("Set source to slow image!");
-	    lv_anim_del(widget->obj, set_img_src);
-	    lv_img_set_src(widget->obj, &slow_img);
-	    current_anim_state = anim_state_slow;
-	}
-    } else {
-	if (current_anim_state != anim_state_fast) {
-	    LOG_DBG("Set source to fast images!");
-            lv_anim_init(&widget->anim);
-	    lv_anim_set_time(&widget->anim, 500);
-	    lv_anim_set_repeat_delay(&widget->anim, 500);
-            lv_anim_set_var(&widget->anim, widget->obj);
-	    lv_anim_set_values(&widget->anim, 0, 1);
-	    lv_anim_set_exec_cb(&widget->anim, set_img_src);
-	    lv_anim_set_repeat_count(&widget->anim, LV_ANIM_REPEAT_INFINITE);
-	    images = fast_images;
-	    current_anim_state = anim_state_fast;
-	    lv_anim_start(&widget->anim);
-	}
-    }
-}
-
 int zaphod_bongo_cat_widget_init(struct zaphod_bongo_cat_widget *widget, lv_obj_t *parent) {
-    widget->obj = lv_img_create(parent, NULL);
-    
+  widget->obj = lv_img_create(parent, NULL);
 
-    lv_img_set_auto_size(widget->obj, true);
-    state_widget_wpm(widget, 0);
+  lv_img_set_auto_size(widget->obj, true);
+  // state_widget_wpm(widget, 0);
 
-    sys_slist_append(&widgets, &widget->node);
+  sys_slist_append(&widgets, &widget->node);
 
-    return 0;
+  return 0;
 }
 
-lv_obj_t *zaphod_bongo_cat_widget_obj(struct zaphod_bongo_cat_widget  *widget) {
-    return widget->obj;
+lv_obj_t *zaphod_bongo_cat_widget_obj(struct zaphod_bongo_cat_widget *widget) {
+  return widget->obj;
 }
-
-int wpm_status_listener(const zmk_event_t *eh) {
-    struct zaphod_bongo_cat_widget *widget;
-    struct zmk_wpm_state_changed *ev = as_zmk_wpm_state_changed(eh);
-    LOG_DBG("LISTENER");
-    SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) { LOG_DBG("Set the WPM %d", ev->state); state_widget_wpm(widget, ev->state); }
-    return ZMK_EV_EVENT_BUBBLE;
-}
-
-ZMK_LISTENER(zaphod_bongo_cat_widget, wpm_status_listener)
-ZMK_SUBSCRIPTION(zaphod_bongo_cat_widget, zmk_wpm_state_changed);

--- a/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.h
+++ b/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.h
@@ -6,7 +6,7 @@
 
 
 #include <lvgl.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 struct zaphod_bongo_cat_widget {
     sys_snode_t node;

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,5 +1,5 @@
 ---
-name: zephyr-config
+name: zaphod-config
 build:
   settings:
     board_root: .


### PR DESCRIPTION
Some types and functions from older LVGL disappeared, changed names, or changed signatures. Also, Zephyr 3.5.0 puts certain headers in a `zephyr/` directory now.

When using zaphod-config as a module, it seems that the Bongo Cat configuration must reside in `Kconfig.shield`